### PR TITLE
Add offline voice agent stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.env
+models/
+*.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,23 +1,110 @@
-### Hi there 👋
+# Agente de voz 100 % local (STT → LLM → TTS)
 
-I am full stack dev looking to solve real world problems. I have a passion for learning and sharing my knowledge with others as publicly as possible.
+Este repositorio contiene una pila completa para ejecutar un asistente de voz estilo ElevenLabs sin conexión a Internet y sin depender de servicios de pago. La solución se divide en tres componentes principales:
 
-<!--
-**josesrs09/josesrs09** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+1. **Reconocimiento de voz (STT)**: basado en Whisper a través de `faster-whisper` y ejecutado de forma local desde el orquestador.
+2. **Modelo de lenguaje (LLM)**: expuesto mediante una API compatible con chat completions que utiliza `llama.cpp` dentro de un contenedor Docker.
+3. **Síntesis de voz (TTS)**: servicio FastAPI que envuelve modelos de `piper-tts` y produce audio WAV localmente.
 
-Here are some ideas to get you started:
+Un orquestador en Python enlaza estos servicios, escucha el micrófono con detección de voz (VAD), transcribe el audio, genera la respuesta con el LLM y la reproduce en voz.
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
-![alt text](https://www.spkcomunicacion.com/wp-content/uploads/2016/12/oferta-programador-web-soria.jpg)
+## Estructura del proyecto
 
-🛠️ Languages and Tools:
+```
+├── configs/agent.yaml          # Parámetros del orquestador
+├── docker-compose.yml          # Orquesta los servicios LLM y TTS
+├── llm/                        # Dockerfile y servidor del modelo de lenguaje
+├── tts/                        # Dockerfile y servidor TTS basado en Piper
+├── orchestrator/               # Código del orquestador y requisitos locales
+└── models/                     # Carpeta (ignoradas por git) para alojar los modelos
+```
 
-JavaScript  Angular Ionic Redux Nodejs Express.js MongoDB Firebase Socket.io Material_UI Bootstrap SCSS HTML5 CSS3 Heroku Git GitHub Gitlab 
+## Requisitos previos
+
+- Docker y Docker Compose.
+- Python 3.10+ para el orquestador.
+- Dependencias del sistema para audio en Linux:
+  ```bash
+  sudo apt-get install -y portaudio19-dev libsndfile1
+  ```
+- Modelos descargados previamente (puede hacerse en otra máquina con Internet y copiarse offline):
+  - **STT**: modelo CTranslate2 de Whisper. Por ejemplo, `faster-whisper-small` convertido a formato CTranslate2 y colocado en `models/stt/whisper-small`.
+  - **LLM**: modelo GGUF compatible con `llama.cpp` (p.ej. `mistral-7b-instruct.Q4_K_M.gguf`) en `models/llm/model.gguf`.
+  - **TTS**: voz de Piper (archivos `.onnx` y `.json`). Ejemplo: `es_ES-mls_8429-low.onnx` y su `.json` en `models/tts/`.
+
+> **Nota:** Los modelos no se incluyen en el repositorio y deben descargarse por separado. La pila funciona completamente offline una vez que los archivos están disponibles localmente.
+
+## Puesta en marcha
+
+### 1. Preparar el entorno de modelos
+
+Cree la estructura de carpetas esperada y copie los modelos previamente descargados:
+
+```
+models/
+├── llm/
+│   └── model.gguf
+├── stt/
+│   └── whisper-small/  # Contiene los ficheros del modelo CTranslate2
+└── tts/
+    ├── voice.onnx
+    └── voice.onnx.json
+```
+
+Ajuste los nombres en `configs/agent.yaml` o en las variables de entorno si sus archivos utilizan otras denominaciones.
+
+### 2. Levantar los servicios LLM y TTS
+
+```bash
+docker compose build
+docker compose up
+```
+
+- El servicio LLM expone `http://localhost:8000/v1/chat/completions` y carga automáticamente el modelo indicado en `MODEL_PATH`.
+- El servicio TTS expone `http://localhost:8001/synthesize` y transforma texto en audio WAV usando Piper.
+
+Ambos contenedores funcionan completamente offline tras cargar los modelos desde los volúmenes montados.
+
+### 3. Instalar el orquestador local
+
+Cree y active un entorno virtual de Python y luego instale los requisitos:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r orchestrator/requirements.txt
+```
+
+### 4. Ejecutar el agente de voz
+
+Con los contenedores corriendo y el entorno activado:
+
+```bash
+python orchestrator/main.py --config configs/agent.yaml
+```
+
+El orquestador:
+
+1. Captura audio del micrófono a 16 kHz usando `sounddevice`.
+2. Detecta segmentos de voz con `webrtcvad` y evita enviar silencio al STT.
+3. Transcribe cada segmento con Whisper (`faster-whisper`).
+4. Añade el mensaje a la conversación y consulta al LLM local por una respuesta.
+5. Solicita al servicio TTS la síntesis de la respuesta y la reproduce por los altavoces.
+
+La configuración por defecto responde en español de forma breve. Puede editar `configs/agent.yaml` para ajustar el prompt del sistema, parámetros del modelo, rutas y comportamiento de reproducción.
+
+### 5. Finalizar
+
+Presione `Ctrl+C` para detener el orquestador. Para apagar los contenedores utilice `docker compose down`.
+
+## Personalización y mejoras
+
+- Cambie el modelo LLM ajustando `MODEL_PATH` y los recursos asignados (`N_THREADS`, `GPU_LAYERS`).
+- Use otra voz de Piper modificando las variables `VOICE_MODEL` y `VOICE_CONFIG` o el archivo de configuración.
+- Ajuste la sensibilidad del VAD mediante `vad_aggressiveness`, `frame_duration_ms` y `padding_duration_ms`.
+- Para mantener memoria de conversaciones largas puede aumentar `max_tokens` o resetear `self.history` en el orquestador según se necesite.
+
+## Licencia
+
+El código del repositorio se publica sin restricciones adicionales. Revise las licencias de cada modelo descargado antes de su uso.

--- a/configs/agent.yaml
+++ b/configs/agent.yaml
@@ -1,0 +1,25 @@
+audio:
+  sample_rate: 16000
+  frame_duration_ms: 30
+  padding_duration_ms: 300
+  vad_aggressiveness: 2
+
+stt:
+  model_path: models/stt/whisper-small
+  language: es
+  compute_type: int8
+  beam_size: 5
+
+llm:
+  url: http://localhost:8000/v1/chat/completions
+  temperature: 0.7
+  max_tokens: 512
+  system_prompt: |
+    Eres un asistente de voz útil que responde en español de forma breve y concreta.
+    Si el usuario saluda, responde cordialmente. Si no sabes algo, admite la limitación.
+
+tts:
+  url: http://localhost:8001/synthesize
+
+playback:
+  wait_for_completion: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+
+services:
+  llm:
+    build: ./llm
+    container_name: local-llm
+    environment:
+      - MODEL_PATH=/models/model.gguf
+      - CONTEXT_SIZE=4096
+      - N_THREADS=6
+      - GPU_LAYERS=0
+      - LLM_PORT=8000
+    volumes:
+      - ./models/llm:/models
+    ports:
+      - "8000:8000"
+
+  tts:
+    build: ./tts
+    container_name: local-tts
+    environment:
+      - VOICE_MODEL=/models/voice.onnx
+      - VOICE_CONFIG=/models/voice.onnx.json
+      - TTS_PORT=8001
+    volumes:
+      - ./models/tts:/models
+    ports:
+      - "8001:8001"

--- a/llm/Dockerfile
+++ b/llm/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py entrypoint.sh ./
+RUN chmod +x entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/llm/entrypoint.sh
+++ b/llm/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${LLM_PORT:-8000}"
+
+exec uvicorn server:app --host 0.0.0.0 --port "${PORT}"

--- a/llm/requirements.txt
+++ b/llm/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+llama-cpp-python==0.2.64
+pydantic==1.10.13

--- a/llm/server.py
+++ b/llm/server.py
@@ -1,0 +1,112 @@
+"""FastAPI server exposing a local llama.cpp model via a chat completion API."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from llama_cpp import Llama
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="Local LLM Server", version="1.0.0")
+
+
+class Message(BaseModel):
+    """Represents a chat message following the OpenAI schema."""
+
+    role: str
+    content: str
+
+
+class ChatRequest(BaseModel):
+    """Request payload for chat completions."""
+
+    messages: List[Message]
+    max_tokens: Optional[int] = 512
+    temperature: Optional[float] = 0.7
+    top_p: Optional[float] = 0.95
+
+
+class ChatResponse(BaseModel):
+    """Response payload returned to clients."""
+
+    text: str
+
+
+llm_model: Optional[Llama] = None
+
+
+@app.on_event("startup")
+def load_model() -> None:
+    """Loads the llama.cpp model when the server starts."""
+
+    global llm_model
+    model_path = os.environ.get("MODEL_PATH", "/models/model.gguf")
+    context_size = int(os.environ.get("CONTEXT_SIZE", "4096"))
+    n_threads = int(os.environ.get("N_THREADS", "4"))
+    gpu_layers = int(os.environ.get("GPU_LAYERS", "0"))
+
+    if not os.path.exists(model_path):
+        msg = (
+            f"Model file not found at '{model_path}'. Make sure to mount the directory "
+            "containing your GGUF model into the container."
+        )
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    logger.info("Loading model from %s", model_path)
+    llm_model = Llama(
+        model_path=model_path,
+        n_ctx=context_size,
+        n_threads=n_threads,
+        n_gpu_layers=gpu_layers,
+        chat_format="chatml",
+    )
+    logger.info("Model loaded successfully")
+
+
+@app.get("/health")
+def healthcheck() -> dict[str, str]:
+    """Simple healthcheck endpoint."""
+
+    if llm_model is None:
+        raise HTTPException(status_code=503, detail="Model not ready")
+    return {"status": "ok"}
+
+
+@app.post("/v1/chat/completions", response_model=ChatResponse)
+def chat_completion(request: ChatRequest) -> ChatResponse:
+    """Generates a chat response using the local llama.cpp backend."""
+
+    if llm_model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    if not request.messages:
+        raise HTTPException(status_code=400, detail="At least one message is required")
+
+    try:
+        completion = llm_model.create_chat_completion(
+            messages=[{"role": msg.role, "content": msg.content} for msg in request.messages],
+            max_tokens=request.max_tokens,
+            temperature=request.temperature,
+            top_p=request.top_p,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("LLM inference failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    try:
+        text = completion["choices"][0]["message"]["content"]
+    except (KeyError, IndexError) as exc:
+        logger.exception("Unexpected response schema: %s", completion)
+        raise HTTPException(status_code=500, detail="Malformed model response") from exc
+
+    logger.info("Response generated: %s", text)
+    return ChatResponse(text=text)
+
+

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,0 +1,285 @@
+"""Offline speech agent orchestrator that links STT, LLM and TTS services."""
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import sys
+import threading
+from collections import deque
+from pathlib import Path
+from typing import Deque, Dict, Iterable, Iterator, List
+
+import numpy as np
+import requests
+import sounddevice as sd
+import wave
+import webrtcvad
+import yaml
+from faster_whisper import WhisperModel
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s: %(message)s")
+
+
+class ConfigError(RuntimeError):
+    """Raised when configuration values are missing or invalid."""
+
+
+class VADSegmenter:
+    """Streams audio from the microphone and yields voice segments using WebRTC VAD."""
+
+    def __init__(
+        self,
+        sample_rate: int,
+        frame_duration_ms: int,
+        padding_duration_ms: int,
+        vad_aggressiveness: int,
+    ) -> None:
+        self.sample_rate = sample_rate
+        self.frame_duration_ms = frame_duration_ms
+        self.padding_duration_ms = padding_duration_ms
+        self.frame_length = int(sample_rate * frame_duration_ms / 1000)
+        self.vad = webrtcvad.Vad(vad_aggressiveness)
+        self.channels = 1
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        """Signals the stream to stop."""
+
+        self._stop_event.set()
+
+    def segments(self) -> Iterator[bytes]:
+        """Generator that yields individual speech segments as PCM16 bytes."""
+
+        with sd.RawInputStream(
+            samplerate=self.sample_rate,
+            blocksize=self.frame_length,
+            dtype="int16",
+            channels=self.channels,
+        ) as stream:
+            logger.info("Escuchando el micrófono… (Ctrl+C para salir)")
+            frames = self._frame_generator(stream)
+            for segment in self._vad_collector(frames):
+                if self._stop_event.is_set():
+                    break
+                yield segment
+
+    def _frame_generator(self, stream: sd.RawInputStream) -> Iterator[bytes]:
+        """Reads audio frames from the input stream."""
+
+        while not self._stop_event.is_set():
+            data, overflowed = stream.read(self.frame_length)
+            if overflowed:
+                logger.warning("Desbordamiento de audio detectado")
+            if not data:
+                continue
+            yield bytes(data)
+
+    def _vad_collector(self, frames: Iterable[bytes]) -> Iterator[bytes]:
+        """Groups frames into voiced segments using a ring buffer."""
+
+        num_padding_frames = int(self.padding_duration_ms / self.frame_duration_ms)
+        ring_buffer: Deque[tuple[bytes, bool]] = deque(maxlen=num_padding_frames)
+        triggered = False
+        voiced_frames: List[bytes] = []
+
+        for frame in frames:
+            if len(frame) == 0:
+                continue
+
+            is_speech = False
+            try:
+                is_speech = self.vad.is_speech(frame, self.sample_rate)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Error evaluando VAD: %s", exc)
+                continue
+
+            if not triggered:
+                ring_buffer.append((frame, is_speech))
+                num_voiced = len([f for f, speech in ring_buffer if speech])
+                if num_voiced > 0.9 * ring_buffer.maxlen:
+                    triggered = True
+                    voiced_frames.extend(f for f, _ in ring_buffer)
+                    ring_buffer.clear()
+                    logger.debug("Voz detectada")
+            else:
+                voiced_frames.append(frame)
+                ring_buffer.append((frame, is_speech))
+                num_unvoiced = len([f for f, speech in ring_buffer if not speech])
+                if num_unvoiced > 0.9 * ring_buffer.maxlen:
+                    logger.debug("Fin de segmento de voz")
+                    yield b"".join(voiced_frames)
+                    ring_buffer.clear()
+                    voiced_frames = []
+                    triggered = False
+
+        if voiced_frames:
+            yield b"".join(voiced_frames)
+
+
+class VoiceAgent:
+    """Coordinates VAD, STT, LLM and TTS services to build a voice agent."""
+
+    def __init__(self, config_path: Path) -> None:
+        self.config = self._load_config(config_path)
+        audio_cfg = self.config["audio"]
+        self.segmenter = VADSegmenter(
+            sample_rate=audio_cfg["sample_rate"],
+            frame_duration_ms=audio_cfg["frame_duration_ms"],
+            padding_duration_ms=audio_cfg["padding_duration_ms"],
+            vad_aggressiveness=audio_cfg.get("vad_aggressiveness", 2),
+        )
+
+        stt_cfg = self.config["stt"]
+        model_path = stt_cfg.get("model_path")
+        if not model_path:
+            raise ConfigError("'stt.model_path' es obligatorio")
+
+        compute_type = stt_cfg.get("compute_type", "int8")
+        logger.info("Cargando modelo STT desde %s", model_path)
+        self.stt_model = WhisperModel(model_path, compute_type=compute_type)
+        self.stt_language = stt_cfg.get("language")
+        self.stt_beam_size = stt_cfg.get("beam_size", 5)
+
+        self.llm_cfg = self.config["llm"]
+        self.tts_cfg = self.config["tts"]
+        playback_cfg = self.config.get("playback", {})
+        self.wait_playback = playback_cfg.get("wait_for_completion", True)
+
+        self.history: List[Dict[str, str]] = []
+        system_prompt = self.llm_cfg.get("system_prompt")
+        if system_prompt:
+            self.history.append({"role": "system", "content": system_prompt})
+
+    @staticmethod
+    def _load_config(path: Path) -> Dict[str, Dict[str, object]]:
+        if not path.exists():
+            raise ConfigError(f"Archivo de configuración no encontrado: {path}")
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+        required_sections = {"audio", "stt", "llm", "tts"}
+        missing = required_sections.difference(data.keys())
+        if missing:
+            raise ConfigError(f"Faltan secciones en la configuración: {', '.join(sorted(missing))}")
+        return data
+
+    def run(self) -> None:
+        """Starts the agent loop."""
+
+        try:
+            for segment in self.segmenter.segments():
+                try:
+                    transcription = self._transcribe(segment)
+                    if not transcription:
+                        continue
+                    logger.info("Usuario: %s", transcription)
+                    reply = self._query_llm(transcription)
+                    logger.info("Asistente: %s", reply)
+                    audio_bytes = self._synthesize(reply)
+                    self._play_audio(audio_bytes)
+                except Exception as exc:  # noqa: BLE001
+                    logger.exception("Error procesando el segmento: %s", exc)
+        except KeyboardInterrupt:
+            logger.info("Interrupción manual, cerrando el agente…")
+        finally:
+            self.segmenter.stop()
+
+    def _transcribe(self, audio_bytes: bytes) -> str:
+        if not audio_bytes:
+            return ""
+
+        audio_np = np.frombuffer(audio_bytes, dtype=np.int16).astype(np.float32)
+        if audio_np.size == 0:
+            return ""
+        audio_np /= 32768.0
+
+        segments, _info = self.stt_model.transcribe(
+            audio_np,
+            language=self.stt_language,
+            beam_size=self.stt_beam_size,
+        )
+        text = " ".join(segment.text.strip() for segment in segments).strip()
+        return text
+
+    def _query_llm(self, user_text: str) -> str:
+        messages = self.history + [{"role": "user", "content": user_text}]
+        payload = {
+            "messages": messages,
+            "temperature": self.llm_cfg.get("temperature", 0.7),
+            "max_tokens": self.llm_cfg.get("max_tokens", 512),
+        }
+        url = self.llm_cfg["url"]
+        try:
+            response = requests.post(url, json=payload, timeout=120)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            logger.exception("Error al contactar el LLM: %s", exc)
+            raise
+
+        data = response.json()
+        reply = data.get("text")
+        if not reply:
+            raise RuntimeError(f"Respuesta inválida del LLM: {data}")
+
+        self.history.extend(
+            [
+                {"role": "user", "content": user_text},
+                {"role": "assistant", "content": reply},
+            ]
+        )
+        return reply.strip()
+
+    def _synthesize(self, text: str) -> bytes:
+        url = self.tts_cfg["url"]
+        payload = {"text": text}
+        try:
+            response = requests.post(url, json=payload, timeout=120)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            logger.exception("Error al contactar el TTS: %s", exc)
+            raise
+        return response.content
+
+    def _play_audio(self, wav_bytes: bytes) -> None:
+        if not wav_bytes:
+            return
+        with wave_open(wav_bytes) as (audio, sample_rate):
+            sd.play(audio, samplerate=sample_rate)
+            if self.wait_playback:
+                sd.wait()
+
+
+@contextmanager
+def wave_open(wav_bytes: bytes) -> Iterator[tuple[np.ndarray, int]]:
+    """Utility context manager that yields PCM data and sample rate from WAV bytes."""
+
+    with io.BytesIO(wav_bytes) as buffer:
+        with wave.open(buffer, "rb") as wav_reader:
+            frames = wav_reader.readframes(wav_reader.getnframes())
+            sample_rate = wav_reader.getframerate()
+            audio = np.frombuffer(frames, dtype=np.int16).astype(np.float32)
+            audio /= 32768.0
+            yield audio, sample_rate
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Agente de voz offline")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/agent.yaml"),
+        help="Ruta al archivo de configuración YAML",
+    )
+    return parser.parse_args(args)
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = parse_args(argv or sys.argv[1:])
+    agent = VoiceAgent(args.config)
+    agent.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -1,0 +1,6 @@
+faster-whisper==0.10.0
+sounddevice==0.4.6
+webrtcvad==2.0.10
+numpy==1.26.4
+PyYAML==6.0.1
+requests==2.31.0

--- a/tts/Dockerfile
+++ b/tts/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libopenblas-dev espeak-ng \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py entrypoint.sh ./
+RUN chmod +x entrypoint.sh
+
+EXPOSE 8001
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/tts/entrypoint.sh
+++ b/tts/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${TTS_PORT:-8001}"
+
+exec uvicorn server:app --host 0.0.0.0 --port "${PORT}"

--- a/tts/requirements.txt
+++ b/tts/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+piper-tts==1.2.0
+numpy==1.26.4

--- a/tts/server.py
+++ b/tts/server.py
@@ -1,0 +1,98 @@
+"""FastAPI server that wraps Piper TTS models for offline synthesis."""
+from __future__ import annotations
+
+import io
+import logging
+import os
+import wave
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Response
+from pydantic import BaseModel
+
+from piper import PiperVoice
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+app = FastAPI(title="Local TTS Server", version="1.0.0")
+
+voice_model: Optional[PiperVoice] = None
+
+
+class SynthesisRequest(BaseModel):
+    """Payload containing the text to be synthesized."""
+
+    text: str
+    speaker_id: Optional[int] = None
+
+
+@app.on_event("startup")
+def load_voice() -> None:
+    """Loads the Piper voice when the service starts."""
+
+    global voice_model
+
+    model_path = os.environ.get("VOICE_MODEL", "/models/voice.onnx")
+    config_path = os.environ.get("VOICE_CONFIG", "/models/voice.onnx.json")
+
+    if not os.path.exists(model_path):
+        msg = (
+            f"Voice model not found at '{model_path}'. Mount the directory with your Piper "
+            "voice files into the container."
+        )
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    if not os.path.exists(config_path):
+        msg = (
+            f"Voice config not found at '{config_path}'. The Piper JSON config must accompany "
+            "the ONNX file."
+        )
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    logger.info("Loading Piper voice from %s", model_path)
+    voice_model = PiperVoice.load(model_path=model_path, config_path=config_path)
+    logger.info("Voice loaded successfully with sample rate %s", voice_model.sample_rate)
+
+
+@app.get("/health")
+def healthcheck() -> dict[str, str]:
+    """Simple endpoint to verify service readiness."""
+
+    if voice_model is None:
+        raise HTTPException(status_code=503, detail="Voice not loaded")
+    return {"status": "ok"}
+
+
+@app.post("/synthesize")
+def synthesize(request: SynthesisRequest) -> Response:
+    """Synthesizes the requested text and returns a WAV audio payload."""
+
+    if voice_model is None:
+        raise HTTPException(status_code=503, detail="Voice not loaded")
+
+    text = request.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Text must not be empty")
+
+    try:
+        audio_chunks = voice_model.synthesize_stream(text, speaker_id=request.speaker_id)
+        audio_bytes = b"".join(audio_chunks)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("TTS synthesis failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(voice_model.sample_rate)
+        wav_file.writeframes(audio_bytes)
+
+    wav_bytes = buffer.getvalue()
+    logger.info("Generated audio with %d bytes", len(wav_bytes))
+    return Response(content=wav_bytes, media_type="audio/wav")
+
+


### PR DESCRIPTION
## Summary
- add a dockerized llama.cpp chat completion server that runs GGUF models locally
- add a dockerized Piper-based TTS API for offline speech synthesis
- add a Python orchestrator with VAD and faster-whisper to bridge STT → LLM → TTS
- document the offline setup and execution workflow in the README

## Testing
- python -m compileall orchestrator llm tts

------
https://chatgpt.com/codex/tasks/task_e_68c9c336458c8331a417f5cf653a2f88